### PR TITLE
Win32 implementation for raw-mode guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,10 @@ name: Test
 on: [ push ]
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-12]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +28,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -77,6 +89,23 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]
@@ -205,6 +234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,16 +270,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+
+[[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "log"
@@ -259,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +339,31 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -287,6 +383,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -360,6 +477,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +528,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "slab"
@@ -401,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +610,8 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "libc",
+ "libloading",
+ "portable-pty",
  "regex",
  "thiserror",
  "tokio",
@@ -458,10 +644,11 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -590,7 +777,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -599,13 +795,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -615,10 +826,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -627,10 +850,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -639,13 +874,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ regex = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt", "sync", "time"] }
 tokio-tungstenite = "0.18.0"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.9", features = ["consoleapi", "processenv", "wincon", "winnt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,11 @@ futures = "0.3.28"
 libc = "0.2"
 regex = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["io-std", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite = "0.18.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.9", features = ["consoleapi", "processenv", "wincon", "winnt"] }
+winapi = { version = "0.3.9", features = ["consoleapi", "namedpipeapi", "processenv", "wincon", "winnt"] }
+
+[dev-dependencies]
+portable-pty = "0.8.1"

--- a/src/bin/test_raw.rs
+++ b/src/bin/test_raw.rs
@@ -1,0 +1,28 @@
+use futures::future::Fuse;
+use futures::FutureExt;
+use thouart::Console;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let mut cons = Console::new_stdio(None).await?;
+    let mut buffer = vec![];
+    loop {
+        let (read_fut, write_fut) = if buffer.is_empty() {
+            (cons.read_stdin().fuse(), Fuse::terminated())
+        } else {
+            (Fuse::terminated(), cons.write_stdout(&buffer).fuse())
+        };
+        tokio::select! {
+            input = read_fut => {
+                match input {
+                    Some(data) => buffer.extend(data),
+                    None => break,
+                }
+            }
+            _ = write_fut => {
+                buffer.clear()
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,49 +2,151 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::os::fd::RawFd;
-use thiserror::Error;
+pub use platform_impl::*;
 
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("tcgetattr(stdout, termios) call failed: {0}")]
-    TcGetAttr(std::io::Error),
-    #[error("tcsetattr(stdout, TCSAFLUSH, termios) call failed: {0}")]
-    TcSetAttr(std::io::Error),
-}
+#[cfg(target_family = "windows")]
+mod platform_impl {
+    use std::os::windows::io::RawHandle;
+    use thiserror::Error;
+    use winapi::shared::minwindef::DWORD;
+    use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
+    use winapi::um::wincon::{
+        DISABLE_NEWLINE_AUTO_RETURN, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT,
+        ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+    };
+    use winapi::um::winnt::HANDLE;
 
-/// Guard object that will set the terminal to raw mode and restore it
-/// to its previous state when it's dropped.
-pub struct RawTermiosGuard(libc::c_int, libc::termios);
+    #[derive(Error, Debug)]
+    pub enum Error {
+        #[error("GetConsoleMode(hConsoleHandle, lpMode) call failed: {0}")]
+        GetConsoleMode(std::io::Error),
+        #[error("SetConsoleMode(hConsoleHandle, dwMode) call failed: {0}")]
+        SetConsoleMode(std::io::Error),
+    }
 
-impl RawTermiosGuard {
-    pub(crate) fn stdio_guard(fd: RawFd) -> Result<RawTermiosGuard, Error> {
-        let termios = unsafe {
-            let mut curr_termios = std::mem::zeroed();
-            let r = libc::tcgetattr(fd, &mut curr_termios);
-            if r == -1 {
-                return Err(Error::TcGetAttr(std::io::Error::last_os_error()));
-            }
-            curr_termios
-        };
-        let guard = RawTermiosGuard(fd, termios);
+    /// Guard object that will set the terminal to raw mode and restore it
+    /// to its previous state when it's dropped.
+    pub struct RawModeGuard {
+        in_handle: HANDLE,
+        out_handle: HANDLE,
+        in_mode: DWORD,
+        out_mode: DWORD,
+    }
+
+    unsafe impl Send for RawModeGuard {}
+
+    fn get_mode(handle: HANDLE) -> Result<DWORD, Error> {
         unsafe {
-            let mut raw_termios = termios;
-            libc::cfmakeraw(&mut raw_termios);
-            let r = libc::tcsetattr(fd, libc::TCSAFLUSH, &raw_termios);
-            if r == -1 {
-                return Err(Error::TcSetAttr(std::io::Error::last_os_error()));
+            let mut curr_mode = std::mem::zeroed();
+            let r = GetConsoleMode(handle, &mut curr_mode);
+            if r == 0 {
+                return Err(Error::GetConsoleMode(std::io::Error::last_os_error()));
+            }
+            Ok(curr_mode)
+        }
+    }
+
+    impl RawModeGuard {
+        pub(crate) fn new(
+            stdin_handle: RawHandle,
+            stdout_handle: RawHandle,
+        ) -> Result<Self, Error> {
+            let in_handle = stdin_handle as HANDLE;
+            let out_handle = stdout_handle as HANDLE;
+            let in_mode = get_mode(in_handle)?;
+            let out_mode = get_mode(out_handle)?;
+            let guard = Self {
+                in_handle,
+                out_handle,
+                in_mode,
+                out_mode,
+            };
+            unsafe {
+                let vt_out_mode = guard.out_mode
+                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                    | DISABLE_NEWLINE_AUTO_RETURN;
+                let r = SetConsoleMode(out_handle, vt_out_mode);
+                if r == 0 {
+                    // may be only failing to disable newline auto-return, try without
+                    let just_vt = guard.out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+                    let r = SetConsoleMode(out_handle, just_vt);
+                    if r == 0 {
+                        return Err(Error::SetConsoleMode(std::io::Error::last_os_error()));
+                    }
+                }
+                let vt_in_mode = (guard.in_mode | ENABLE_VIRTUAL_TERMINAL_INPUT)
+                    & !(ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT | ENABLE_ECHO_INPUT);
+                let r = SetConsoleMode(in_handle, vt_in_mode);
+                if r == 0 {
+                    return Err(Error::SetConsoleMode(std::io::Error::last_os_error()));
+                }
+            }
+            Ok(guard)
+        }
+    }
+
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let r = SetConsoleMode(self.in_handle, self.in_mode);
+                if r == 0 {
+                    Err::<(), _>(std::io::Error::last_os_error()).unwrap();
+                }
+                let r = SetConsoleMode(self.out_handle, self.out_mode);
+                if r == 0 {
+                    Err::<(), _>(std::io::Error::last_os_error()).unwrap();
+                }
             }
         }
-        Ok(guard)
     }
 }
 
-impl Drop for RawTermiosGuard {
-    fn drop(&mut self) {
-        let r = unsafe { libc::tcsetattr(self.0, libc::TCSADRAIN, &self.1) };
-        if r == -1 {
-            Err::<(), _>(std::io::Error::last_os_error()).unwrap();
+#[cfg(target_family = "unix")]
+mod platform_impl {
+    use std::os::fd::RawFd;
+    use thiserror::Error;
+
+    #[derive(Error, Debug)]
+    pub enum Error {
+        #[error("tcgetattr(stdout, termios) call failed: {0}")]
+        TcGetAttr(std::io::Error),
+        #[error("tcsetattr(stdout, TCSAFLUSH, termios) call failed: {0}")]
+        TcSetAttr(std::io::Error),
+    }
+
+    /// Guard object that will set the terminal to raw mode and restore it
+    /// to its previous state when it's dropped.
+    pub struct RawModeGuard(libc::c_int, libc::termios);
+
+    impl RawModeGuard {
+        pub(crate) fn new(fd: RawFd) -> Result<Self, Error> {
+            let termios = unsafe {
+                let mut curr_termios = std::mem::zeroed();
+                let r = libc::tcgetattr(fd, &mut curr_termios);
+                if r == -1 {
+                    return Err(Error::TcGetAttr(std::io::Error::last_os_error()));
+                }
+                curr_termios
+            };
+            let guard = Self(fd, termios);
+            unsafe {
+                let mut raw_termios = termios;
+                libc::cfmakeraw(&mut raw_termios);
+                let r = libc::tcsetattr(fd, libc::TCSAFLUSH, &raw_termios);
+                if r == -1 {
+                    return Err(Error::TcSetAttr(std::io::Error::last_os_error()));
+                }
+            }
+            Ok(guard)
+        }
+    }
+
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            let r = unsafe { libc::tcsetattr(self.0, libc::TCSADRAIN, &self.1) };
+            if r == -1 {
+                Err::<(), _>(std::io::Error::last_os_error()).unwrap();
+            }
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,45 @@
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::io::{Read, Write};
+
+#[test]
+fn test_portable_pty() -> Result<(), Box<dyn std::error::Error>> {
+    let pty_system = native_pty_system();
+    let pair = pty_system.openpty(PtySize::default())?;
+
+    // test_raw.rs just echoes the characters we feed it.
+    let cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_test_raw"));
+
+    let mut child = pair.slave.spawn_command(cmd)?;
+    let mut reader = pair.master.try_clone_reader()?;
+    let mut writer = pair.master.take_writer()?;
+
+    // print some printable character, read until we see it, repeat once.
+    // clears out garbage that windows echoes that interferes with our test.
+    for msg in [b"@", b"%"] {
+        let mut buf = [0u8];
+        writer.write_all(msg)?;
+        writer.flush()?;
+        while &buf != msg {
+            reader.read_exact(&mut buf)?;
+        }
+    }
+
+    // the `3` in here would count as a ctrl+C and kill the process if we were
+    // cooked, which we shouldn't be if we're in raw mode.
+    writer.write_all(&[3])?;
+    writer.flush()?;
+
+    // again for windows, definitively flush out the junk the above produces,
+    // then make sure the process is still alive after the ctrl+C.
+    let mut buf = [0u8];
+    writer.write_all(b"$")?;
+    writer.flush()?;
+    while &buf != b"$" {
+        reader.read_exact(&mut buf)?;
+    }
+    assert!(child.try_wait()?.is_none());
+
+    child.kill()?;
+
+    Ok(())
+}


### PR DESCRIPTION
Uses the VT100 emulation support in Windows 10 as of build 10586 (2015).

Relevant API docs:
- https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
- https://learn.microsoft.com/en-us/windows/console/high-level-console-modes

![image](https://github.com/oxidecomputer/thouart/assets/629075/219ef399-a163-4055-aef7-1943f96c2fb7)
