### PR TITLE
lazily initialize raw-mode guard

### DIFF
--- a/src/bin/test_raw.rs
+++ b/src/bin/test_raw.rs
@@ -5,6 +5,10 @@ use thouart::Console;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let mut cons = Console::new_stdio(None).await?;
+
+    // force raw-mode initialization
+    cons.write_stdout(&[]).await?;
+
     let mut buffer = vec![];
     loop {
         let (read_fut, write_fut) = if buffer.is_empty() {


### PR DESCRIPTION
only construct the RawModeGuard when we have something to output to the terminal.
if an error occurs before we ever receive output -- such as when an instance doesn't exist -- we don't have any terminal state to reset.
https://github.com/oxidecomputer/oxide.rs/issues/668